### PR TITLE
Attempt to fix type cast error, take 2

### DIFF
--- a/PowerProcess/InvokeProcessFast.cs
+++ b/PowerProcess/InvokeProcessFast.cs
@@ -672,10 +672,10 @@ namespace PowerProcess
             var l = stream as IList;
             var lst = target switch
             {
-                FinalTarget.OutObjLst => ((List<string>)stream!).ToArray(),
-                FinalTarget.ErrObjLst => ((List<string>)stream!).ToArray(),
-                FinalTarget.OutStrLst => ((List<object>)stream!).ToArray(),
-                FinalTarget.ErrStrLst => ((List<object>)stream!).ToArray(),
+                FinalTarget.OutObjLst => ((List<object>)stream!).ToArray(),
+                FinalTarget.ErrObjLst => ((List<object>)stream!).ToArray(),
+                FinalTarget.OutStrLst => ((List<string>)stream!).ToArray(),
+                FinalTarget.ErrStrLst => ((List<string>)stream!).ToArray(),
                 _ => null,
             };
             if (lst == null || lst.Length == 0) return;


### PR DESCRIPTION
This is my educated guess on how to fix:
```
Unable to cast object of type 'System.Collections.Generic.List`1[System.Object]' to type 'System.Collections.Generic.List`1[System.String]
```
I've matched `OutObjLst, ErrObjLst` with `List<object>` and `OutStrLst, ErrStrLst` with List<string>. After compiling, I no longer see this error in any of the tests from `Invoke-ProcessFast-Wait-Tests.ps1`.

By the way: I'm sorry for the mess during the first attempt.